### PR TITLE
Cleaned up sample after running with cleared config

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,8 +113,7 @@ func healthy(endpoint string, transport *http.Transport) <-chan bool {
 }
 
 func registerMyHealthchecks(kvs kvstore.KVStore) error {
-	config.RegisterHealthCheckForBackend(kvs, "quote-backend", healthy)
-	return nil
+	return config.RegisterHealthCheckForBackend(kvs, "quote-backend", healthy)
 }
 
 func main() {

--- a/runhcsample.sh
+++ b/runhcsample.sh
@@ -7,7 +7,7 @@ export XAVI_KVSTORE_URL=file:///`pwd`/config
 ./xavisample add-server -address localhost -port 4646 -name quotesvr2 -health-check-interval 5000 -health-check-timeout 2000 -health-check custom-http -ping-uri /
 ./xavisample add-server -address localhost -port 4747 -name quotesvr3 -health-check-interval 5000 -health-check-timeout 2000 -health-check custom-http -ping-uri /
 ./xavisample add-backend -name quote-backend -servers quotesvr1,quotesvr2,quotesvr3 -load-balancer-policy prefer-local
-./xavisample add-route -name quote-route -backends quote-backend,qb2 -base-uri /quote/ -plugins Quote,SessionId,Timing,Recovery
+./xavisample add-route -name quote-route -backends quote-backend -base-uri /quote/ -plugins Quote,SessionId,Timing,Recovery
 ./xavisample add-listener -name quote-listener -routes quote-route
 
 ./xavisample listen -ln quote-listener -address 0.0.0.0:8080


### PR DESCRIPTION
Change to main.go used to reproduce config errors seen by others, then to verify the change to xavi to ensure health check registration is only performed when booting a listener. Also did testing with cleaned out configuration and fixed the custom health check config.
